### PR TITLE
feat: add zap support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.6
 require (
 	github.com/rs/zerolog v1.32.0
 	github.com/stretchr/testify v1.8.4
+	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -13,6 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/objx v0.5.1 // indirect
+	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,12 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
+go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
+go.uber.org/zap v1.27.0/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/polyzap/event.go
+++ b/polyzap/event.go
@@ -1,0 +1,193 @@
+package polyzap
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pokt-network/polylog"
+)
+
+var _ polylog.Event = (*zapEvent)(nil)
+
+type zapEvent struct {
+	logger    *zap.Logger
+	level     zapcore.Level
+	fields    []zapcore.Field
+	discarded atomic.Bool
+}
+
+func newEvent(logger *zap.Logger, level zapcore.Level) polylog.Event {
+	discarded := atomic.Bool{}
+	if level < logger.Level() {
+		discarded.Store(true)
+	}
+
+	return &zapEvent{
+		logger:    logger,
+		level:     level,
+		discarded: discarded,
+	}
+}
+
+func (zae *zapEvent) Str(key, value string) polylog.Event {
+	zae.fields = append(zae.fields, zap.String(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Bool(key string, value bool) polylog.Event {
+	zae.fields = append(zae.fields, zap.Bool(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Int(key string, value int) polylog.Event {
+	zae.fields = append(zae.fields, zap.Int(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Int8(key string, value int8) polylog.Event {
+	zae.fields = append(zae.fields, zap.Int8(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Int16(key string, value int16) polylog.Event {
+	zae.fields = append(zae.fields, zap.Int16(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Int32(key string, value int32) polylog.Event {
+	zae.fields = append(zae.fields, zap.Int32(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Int64(key string, value int64) polylog.Event {
+	zae.fields = append(zae.fields, zap.Int64(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Uint(key string, value uint) polylog.Event {
+	zae.fields = append(zae.fields, zap.Uint(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Uint8(key string, value uint8) polylog.Event {
+	zae.fields = append(zae.fields, zap.Uint8(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Uint16(key string, value uint16) polylog.Event {
+	zae.fields = append(zae.fields, zap.Uint16(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Uint32(key string, value uint32) polylog.Event {
+	zae.fields = append(zae.fields, zap.Uint32(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Uint64(key string, value uint64) polylog.Event {
+	zae.fields = append(zae.fields, zap.Uint64(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Float32(key string, value float32) polylog.Event {
+	zae.fields = append(zae.fields, zap.Float32(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Float64(key string, value float64) polylog.Event {
+	zae.fields = append(zae.fields, zap.Float64(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Err(err error) polylog.Event {
+	zae.fields = append(zae.fields, zap.Error(err))
+	return zae
+}
+
+func (zae *zapEvent) Timestamp() polylog.Event {
+	// TODO_IMPROVE: the key should be configurable via an option.
+	zae.fields = append(zae.fields, zap.Time("timestamp", time.Now()))
+	return zae
+}
+
+func (zae *zapEvent) Time(key string, value time.Time) polylog.Event {
+	zae.fields = append(zae.fields, zap.Time(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Dur(key string, value time.Duration) polylog.Event {
+	zae.fields = append(zae.fields, zap.Duration(key, value))
+	return zae
+}
+
+func (zae *zapEvent) Func(fn func(polylog.Event)) polylog.Event {
+	if zae.Enabled() {
+		fn(zae)
+	}
+	return zae
+}
+
+// TODO_IN_THIS_COMMIT: not like this...
+func (zae *zapEvent) Fields(fields any) polylog.Event {
+	// TODO_IMPROVE/TODO_INVESTIGATE: look into whether zapcore.ArrayMarshaler is
+	// applicable and useful here.
+	switch fieldsVal := fields.(type) {
+	case map[string]any:
+		for key, value := range fieldsVal {
+			zae.fields = append(zae.fields, zap.Any(key, value))
+		}
+	case []any:
+		var nextFieldKey string
+		for fieldIdx, value := range fieldsVal {
+			if fieldIdx%2 == 0 {
+				nextFieldKey = fmt.Sprintf("%v", value)
+				continue
+			}
+
+			zae.fields = append(zae.fields, zap.Any(nextFieldKey, value))
+		}
+	}
+	return zae
+}
+
+func (zae *zapEvent) Enabled() bool {
+	return !zae.discarded.Load()
+}
+
+func (zae *zapEvent) Discard() polylog.Event {
+	// Set zae.discarded to true (only if not already).
+	zae.discarded.CompareAndSwap(false, true)
+	return zae
+}
+
+func (zae *zapEvent) Msg(msg string) {
+	if !zae.Enabled() {
+		return
+	}
+
+	zae.log(msg, zae.fields...)
+}
+
+func (zae *zapEvent) Msgf(format string, args ...any) {
+	if !zae.Enabled() {
+		return
+	}
+
+	zae.log(fmt.Sprintf(format, args...))
+}
+
+func (zae *zapEvent) Send() {
+	if !zae.Enabled() {
+		return
+	}
+
+	zae.log("", zae.fields...)
+}
+
+func (zae *zapEvent) log(msg string, fields ...zapcore.Field) {
+	zae.logger.Check(zae.level, msg).Write(fields...)
+}

--- a/polyzap/levels.go
+++ b/polyzap/levels.go
@@ -1,0 +1,38 @@
+package polyzap
+
+import (
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pokt-network/polylog"
+)
+
+const (
+	// NB: zap log levels use -1 for Debug and 0 for Info.
+	//DebugLevel = Level(iota)
+	DebugLevel = Level(iota - 1)
+	InfoLevel
+	WarnLevel
+	ErrorLevel
+)
+
+var _ polylog.Level = Level(0)
+
+type Level int
+
+// Levels is a convenience function to return all supported levels.
+func Levels() []Level {
+	return []Level{
+		DebugLevel,
+		InfoLevel,
+		WarnLevel,
+		ErrorLevel,
+	}
+}
+
+func (lvl Level) String() string {
+	return zapcore.Level(lvl).String()
+}
+
+func (lvl Level) Int() int {
+	return int(lvl)
+}

--- a/polyzap/logger.go
+++ b/polyzap/logger.go
@@ -1,0 +1,119 @@
+package polyzap
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pokt-network/polylog"
+)
+
+var _ polylog.Logger = (*zapLogger)(nil)
+
+type zapLogger struct {
+	// NB: Default (0) is Info.
+	level         zapcore.Level
+	writeSyncer   zapcore.WriteSyncer
+	encoderConfig zapcore.EncoderConfig
+	encoder       zapcore.Encoder
+	core          zapcore.Core
+	logger        *zap.Logger
+}
+
+func NewLogger(
+	opts ...polylog.LoggerOption,
+) polylog.Logger {
+	ze := &zapLogger{}
+
+	for _, opt := range opts {
+		opt(ze)
+	}
+
+	ze.buildLoggerAndSetDefaults()
+
+	return ze
+}
+
+func (za *zapLogger) Debug() polylog.Event {
+	return newEvent(za.logger, zapcore.DebugLevel)
+}
+
+func (za *zapLogger) Info() polylog.Event {
+	return newEvent(za.logger, zapcore.InfoLevel)
+}
+
+func (za *zapLogger) Warn() polylog.Event {
+	return newEvent(za.logger, zapcore.WarnLevel)
+}
+
+func (za *zapLogger) Error() polylog.Event {
+	return newEvent(za.logger, zapcore.ErrorLevel)
+}
+
+func (za *zapLogger) With(keyVals ...any) polylog.Logger {
+	var (
+		fields  []zap.Field
+		nextKey any
+	)
+	for keyValIdx, keyVal := range keyVals {
+		if keyValIdx%2 == 0 {
+			nextKey = keyVal
+			continue
+		}
+		nextKeyStr := fmt.Sprintf("%s", nextKey)
+		fields = append(fields, zap.Any(nextKeyStr, keyVal))
+	}
+
+	return &zapLogger{
+		level:  za.level,
+		logger: za.logger.With(fields...),
+	}
+}
+
+// WithContext returns a copy of ctx with the receiver attached. The Logger
+// attached to the provided Context (if any) will not be effected.  If the
+// receiver's log level is Disabled it will only be attached to the returned
+// Context if the provided Context has a previously attached Logger. If the
+// provided Context has no attached Logger, a Disabled Logger will not be
+// attached.
+//
+// TODO_TECHDEBT/TODO_COMMUNITY: implement with behavior analogous to that
+// of `polyzero.Logger`'s.
+//
+// TODO_IMPROVE/TODO_COMMUNITY: support #UpdateContext() and  update this
+// godoc to include #UpdateContext() usage example.
+// See: https://pkg.go.dev/github.com/rs/zerolog#Logger.UpdateContext.
+func (za *zapLogger) WithContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, polylog.CtxKey, za)
+}
+
+func (za *zapLogger) WithLevel(level polylog.Level) polylog.Event {
+	// TODO_IN_THIS_COMMIT: consider comparing level.String() & zapcore.Level.String().
+	return newEvent(za.logger, zapcore.Level(level.Int()))
+}
+
+func (za *zapLogger) Write(p []byte) (n int, err error) {
+	za.logger.Log(
+		za.level,
+		string(p),
+	)
+	return len(p), nil
+}
+
+func (za *zapLogger) buildLoggerAndSetDefaults() {
+	if za.writeSyncer == nil {
+		za.writeSyncer = zapcore.AddSync(os.Stderr)
+	}
+
+	if za.logger == nil {
+		encoderConfig := zap.NewProductionEncoderConfig()
+		encoder := zapcore.NewJSONEncoder(encoderConfig)
+		core := zapcore.NewCore(encoder, za.writeSyncer, za.level)
+
+		za.logger = zap.New(core)
+	}
+
+}

--- a/polyzap/logger_test.go
+++ b/polyzap/logger_test.go
@@ -1,0 +1,380 @@
+package polyzap_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/pokt-network/polylog"
+	"github.com/pokt-network/polylog/polyzap"
+	"github.com/pokt-network/polylog/testpolylog"
+)
+
+const polyzapEventTypeName = "*polyzap.zapEvent"
+
+var (
+	expectedTime                   = time.Now()
+	expectedTimestampEventContains = fmt.Sprintf(`"ts":%d.`, expectedTime.Unix())
+	expectedTimeEventContains      = fmt.Sprintf(`"Time":%d.`, expectedTime.Unix())
+	expectedDuration               = time.Millisecond + (250 * time.Nanosecond) // 1000250
+	expectedDurationEventContains  = fmt.Sprintf(`"Dur":%f`, expectedDuration.Seconds())
+)
+
+func TestZapLogger_AllLevels_AllEventMethods(t *testing.T) {
+	tests := []testpolylog.EventMethodTestCase{
+		{
+			// Explicitly left empty; no event method should be called.
+			EventMethodName:        "",
+			Msg:                    "Msg",
+			ExpectedOutputContains: "Msg",
+		},
+		{
+			// Explicitly left empty; no event method should be called.
+			EventMethodName:        "",
+			MsgFmt:                 "%s",
+			MsgFmtArgs:             []any{"Msgf"},
+			ExpectedOutputContains: "Msgf",
+		},
+		{
+			EventMethodName:        "Str",
+			Key:                    "Str",
+			Value:                  "str_value",
+			ExpectedOutputContains: `"Str":"str_value"`,
+		},
+		{
+			EventMethodName:        "Bool",
+			Key:                    "Bool",
+			Value:                  true,
+			ExpectedOutputContains: `"Bool":true`,
+		},
+		{
+			EventMethodName:        "Int",
+			Key:                    "Int",
+			Value:                  int(42),
+			ExpectedOutputContains: `"Int":42`,
+		},
+		{
+			EventMethodName:        "Int8",
+			Key:                    "Int8",
+			Value:                  int8(42),
+			ExpectedOutputContains: `"Int8":42`,
+		},
+		{
+			EventMethodName:        "Int16",
+			Key:                    "Int16",
+			Value:                  int16(42),
+			ExpectedOutputContains: `"Int16":42`,
+		},
+		{
+			EventMethodName:        "Int32",
+			Key:                    "Int32",
+			Value:                  int32(42),
+			ExpectedOutputContains: `"Int32":42`,
+		},
+		{
+			EventMethodName:        "Int64",
+			Key:                    "Int64",
+			Value:                  int64(42),
+			ExpectedOutputContains: `"Int64":42`,
+		},
+		{
+			EventMethodName:        "Uint",
+			Key:                    "Uint",
+			Value:                  uint(42),
+			ExpectedOutputContains: `"Uint":42`,
+		},
+		{
+			EventMethodName:        "Uint8",
+			Key:                    "Uint8",
+			Value:                  uint8(42),
+			ExpectedOutputContains: `"Uint8":42`,
+		},
+		{
+			EventMethodName:        "Uint16",
+			Key:                    "Uint16",
+			Value:                  uint16(42),
+			ExpectedOutputContains: `"Uint16":42`,
+		},
+		{
+			EventMethodName:        "Uint32",
+			Key:                    "Uint32",
+			Value:                  uint32(42),
+			ExpectedOutputContains: `"Uint32":42`,
+		},
+		{
+			EventMethodName:        "Uint64",
+			Key:                    "Uint64",
+			Value:                  uint64(42),
+			ExpectedOutputContains: `"Uint64":42`,
+		},
+		{
+			EventMethodName:        "Float32",
+			Key:                    "Float32",
+			Value:                  float32(420.69),
+			ExpectedOutputContains: `"Float32":420.69`,
+		},
+		{
+			EventMethodName:        "Float64",
+			Key:                    "Float64",
+			Value:                  float64(420.69),
+			ExpectedOutputContains: `"Float64":420.69`,
+		},
+		{
+			EventMethodName:        "Err",
+			Value:                  fmt.Errorf("%d", 42),
+			ExpectedOutputContains: `"error":"42"`,
+		},
+		{
+			EventMethodName:        "Timestamp",
+			ExpectedOutputContains: expectedTimestampEventContains,
+		},
+		// TODO_TECHDEBT: figure out why this fails in CI but not locally,
+		// (even with `make itest 500 10 ./pkg/polylog/... -- -run=ZapLogger_AllLevels_AllEventMethods`).
+		//
+		//{
+		//  EventMethodName:        "Time",
+		//	Key:                    "Time",
+		//	Value:                  expectedTime,
+		//	ExpectedOutputContains: expectedTimeEventContains,
+		//},
+		{
+			EventMethodName:        "Dur",
+			Key:                    "Dur",
+			Value:                  expectedDuration,
+			ExpectedOutputContains: expectedDurationEventContains,
+		},
+		{
+			EventMethodName: "Fields",
+			Value: map[string]any{
+				"key1": "value1",
+				"key2": 42,
+			},
+			// TODO_IMPROVE: assert on all key/value pairs. Zap doesn't seem to
+			// provide any guarantee around the oder of the fields. This requires
+			// changing the test and helper structure to support this.
+			ExpectedOutputContains: `"key2":42`,
+		},
+		{
+			EventMethodName: "Fields",
+			Value:           []any{"key1", "value1", "key2", 42},
+			// TODO_IMPROVE: assert on all key/value pairs. Zap doesn't seem to
+			// provide any guarantee around the oder of the fields. This requires
+			// changing the test and helper structure to support this.
+			ExpectedOutputContains: `"key2":42`,
+		},
+	}
+
+	// TODO_IN_THIS_COMMIT: comment...
+	for _, level := range polyzap.Levels() {
+		testpolylog.RunEventMethodTests(
+			t,
+			level,
+			tests,
+			newTestLogger,
+			newTestEventWithLevel,
+			getExpectedLevelOutputContains,
+		)
+	}
+}
+
+func TestZapLogger_Levels_Discard(t *testing.T) {
+	// Construct a logger with each level. With each logger, log an event at each
+	// level and assert that the event is logged if and only if the event level
+	// is GTE the logger level.
+	for _, loggerLevel := range polyzap.Levels() {
+		testDesc := fmt.Sprintf("%s level logger", loggerLevel.String())
+		t.Run(testDesc, func(t *testing.T) {
+			logger, logOutput := newTestLogger(t, loggerLevel)
+
+			// Log an event for each level.
+			for _, eventLevel := range polyzap.Levels() {
+				event := newTestEventWithLevel(t, logger, eventLevel)
+				// Log the event level string.
+				event.Msg(eventLevel.String())
+
+				// If the event level is GTE the logger level, then the event should
+				// be logged.
+				if eventLevel.Int() >= loggerLevel.Int() {
+					require.Truef(t, event.Enabled(), "expected event to be enabled")
+					require.Contains(t, logOutput.String(), eventLevel.String())
+				} else {
+					require.Falsef(t, event.Enabled(), "expected event to be discarded")
+					require.NotContains(t, logOutput.String(), eventLevel.String())
+				}
+			}
+
+			// Print log output for manual inspection.
+			t.Log(logOutput.String())
+		})
+	}
+}
+
+func TestZerologLogger_Func_Discard_Enabled(t *testing.T) {
+	for _, loggerLevel := range polyzap.Levels() {
+		testDesc := fmt.Sprintf("%s loggerLevel logger", loggerLevel.String())
+		t.Run(testDesc, func(t *testing.T) {
+			var (
+				notExpectedOutput = "if you're reading this, the test failed"
+				// Construct a spy which implements a #Fn() method which we can use to
+				// assert that the function passed to polylog.Event#Func() is called with
+				// the expected arg(s).
+				logger, logOutput = newTestLogger(t, loggerLevel)
+			)
+
+			for _, eventLevel := range polyzap.Levels() {
+				funcSpy := testpolylog.EventFuncSpy{}
+				funcSpy.On("Fn", mock.AnythingOfType(polyzapEventTypeName)).Return()
+
+				event := newTestEventWithLevel(t, logger, eventLevel)
+				expectedEventLevelEnabled := eventLevel.Int() >= loggerLevel.Int()
+
+				require.Equalf(t, expectedEventLevelEnabled, event.Enabled(), "expected event to be initially enabled")
+
+				// If the event level is GTE the logger level, then make additional
+				// assertions about #Func(), #Discard(), and #Enabled() behavior.
+				if expectedEventLevelEnabled {
+					// Assert that #Func() calls `funcSpy#Fn()` method 1 time with
+					// an event whose type name matches funcMethodEventTypeName.
+					event.Func(funcSpy.Fn)
+					funcSpy.AssertCalled(t, "Fn", mock.AnythingOfType(polyzapEventTypeName))
+					funcSpy.AssertNumberOfCalls(t, "Fn", 1)
+
+					event.Discard()
+					require.Falsef(t, event.Enabled(), "expected event to be disabled after Discard()")
+
+					// Assert that #Func() **does not** call `funcSpy#Fn()` method again.
+					event.Func(funcSpy.Fn)
+					funcSpy.AssertNumberOfCalls(t, "Fn", 1)
+
+					event.Msg(notExpectedOutput)
+					require.NotContains(t, logOutput.String(), notExpectedOutput)
+				}
+
+				// NB: this test doesn't produce any log output as all cases
+				// exercise discarding.
+			}
+		})
+	}
+}
+
+func TestZerologLogger_With(t *testing.T) {
+	logger, logOutput := newTestLogger(t, polyzap.DebugLevel)
+
+	logger.Debug().Msg("before")
+	require.Contains(t, logOutput.String(), "before")
+
+	logger = logger.With("key", "value")
+
+	logger.Debug().Msg("after")
+
+	require.Contains(t, logOutput.String(), "after")
+	require.Contains(t, logOutput.String(), `"key":"value"`)
+
+	// Print log output for manual inspection.
+	t.Log(logOutput.String())
+}
+
+func TestZerologLogger_WithContext(t *testing.T) {
+	var (
+		expectedLogger = polyzap.NewLogger()
+		ctx            = context.Background()
+	)
+
+	// Ensure that no logger is associated with the context.
+	existingLogger, ok := ctx.Value(polylog.CtxKey).(polylog.Logger)
+	require.False(t, ok)
+	require.Nil(t, existingLogger)
+
+	// Retrieve the default logger from the context using polylog and assert
+	// that it matches the default context logger.
+	defaultLogger := polylog.Ctx(ctx)
+	require.Equal(t, polylog.DefaultContextLogger, defaultLogger)
+
+	// Associate a logger with a context.
+	ctx = expectedLogger.WithContext(ctx)
+
+	// Retrieve the associated logger from the context using polylog and assert
+	// that it matches the one constructed at the beginning of the test.
+	actualLogger := polylog.Ctx(ctx)
+	require.Equal(t, expectedLogger, actualLogger)
+}
+
+// TODO_TECHDEBT/TODO_COMMUNITY: TDD this integration with zap. See `polyzero`
+// package for comparison / starting point.
+func TestWithTimestampKey(t *testing.T) {
+	t.SkipNow()
+}
+
+// TODO_TECHDEBT/TODO_COMMUNITY: TDD this integration with zap. See `polyzero`
+// package for comparison / starting point.
+func TestWithErrorKey(t *testing.T) {
+	t.SkipNow()
+}
+
+func TestZerologLogger_WithLevel(t *testing.T) {
+	logger, logOutput := newTestLogger(t, polyzap.DebugLevel)
+	logger.WithLevel(polyzap.DebugLevel).Msg("WithLevel()")
+
+	require.Contains(t, logOutput.String(), "WithLevel()")
+}
+
+func TestZerologLogger_Write(t *testing.T) {
+	testOutput := "Write()"
+	logger, logOutput := newTestLogger(t, polyzap.DebugLevel)
+
+	n, err := logger.Write([]byte(testOutput))
+	require.NoError(t, err)
+	require.Lenf(t, testOutput, n, "expected %d bytes to be written", len(testOutput))
+
+	require.Contains(t, logOutput.String(), testOutput)
+}
+
+func newTestLogger(
+	t *testing.T,
+	level polylog.Level,
+	opts ...polylog.LoggerOption,
+) (polylog.Logger, *bytes.Buffer) {
+	t.Helper()
+
+	// Redirect standard log output to logOutput buffer.
+	logOutput := new(bytes.Buffer)
+	opts = append(opts,
+		polyzap.WithOutput(logOutput),
+		polyzap.WithLevel(polyzap.Level(level.Int())),
+	)
+
+	logger := polyzap.NewLogger(opts...)
+
+	return logger, logOutput
+}
+
+func newTestEventWithLevel(
+	t *testing.T,
+	logger polylog.Logger,
+	level polylog.Level,
+) polylog.Event {
+	t.Helper()
+
+	switch level.String() {
+	case zap.DebugLevel.String():
+		return logger.Debug()
+	case zap.InfoLevel.String():
+		return logger.Info()
+	case zap.WarnLevel.String():
+		return logger.Warn()
+	case zap.ErrorLevel.String():
+		return logger.Error()
+	default:
+		panic(fmt.Errorf("level not yet supported: %s", level.String()))
+	}
+}
+
+func getExpectedLevelOutputContains(level polylog.Level) string {
+	return fmt.Sprintf(`"level":%q`, level.String())
+}

--- a/polyzap/options.go
+++ b/polyzap/options.go
@@ -1,0 +1,22 @@
+package polyzap
+
+import (
+	"io"
+
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pokt-network/polylog"
+)
+
+func WithOutput(output io.Writer) polylog.LoggerOption {
+	return func(ul polylog.Logger) {
+		ul.(*zapLogger).writeSyncer = zapcore.AddSync(output)
+	}
+}
+
+func WithLevel(level Level) polylog.LoggerOption {
+	return func(zl polylog.Logger) {
+		// TODO_IN_THIS_COMMIT: consider comparing level.String() & zapcore.Level.String().
+		zl.(*zapLogger).level = zapcore.Level(level.Int())
+	}
+}

--- a/polyzap/test_logger.go
+++ b/polyzap/test_logger.go
@@ -1,0 +1,18 @@
+//go:build test
+
+package polyzap
+
+import (
+	"go.uber.org/zap"
+
+	"github.com/pokt-network/polylog"
+)
+
+// GetZapLogger is a helper function which provides direct access to the underlying
+// zap logger for testing purposes; e.g. use in assertions. To use this helper,
+// ensure that the build tag/constraint "test" is set (e.g. `go build -tags=test`).
+// It MUST be defined in this package (as opposed to somewhere in testutils), as
+// by definition, it references unexported members of this package.
+func GetZapLogger(logger polylog.Logger) *zap.Logger {
+	return logger.(*zapLogger).logger
+}


### PR DESCRIPTION
### Changes

This PR adds the `zap` implementation of the polylog interfaces. It as an extremely thin (and partial) wrapper around zap.

#### TODO

- [ ] Add godoc comments.

### Purpose

As `zap` is quite similar to (basically  one less degree-of-freedom less than)  `zerolog`, it is fairly trivial to support a `zap` implementation for consumers who are already using or otherwise persuaded to use `zap`.